### PR TITLE
Update for Alfresco 6.2.0, add endpoint specifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-# NO LONGER MAINTAINED
-This repo is no longer maintained. Several contributors have forked it and are continuing development and SDK updates.
-
- * https://github.com/douglascrp/alfresco-cloud-store
- * https://github.com/Redpill-Linpro/alfresco-s3-adapter
-
 # alfresco-s3-adapter
 Alfresco AMP Module for S3 Backed Storage
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 # alfresco-s3-adapter
-Alfresco AMP Module for S3 Backed Storage
+### Alfresco AMP Module for S3 Backed Storage
+
+This module enables Alfresco to use the S3 storage as configured in `alfresco-global.properties` as the content store.
 
  * Migrated from the `alfresco-cloud-store` project at https://code.google.com/p/alfresco-cloud-store/
- * Updated to use the latest AWS S3 SDK, and the latest Alfresco 5.0.x API
+ * Updated to use AWS S3 SDK 1.11.106, Alfresco 6.2.0-ga API
  * This should not be considered "production ready" it has not been battle tested
  * Pull Requests / Issues / Contributions are welcomed!
  
-Build Instructions
+### Build Instructions
 
  * After cloning the project, run `mvn clean install` to download dependencies and build the project
 
-Installation / Configuration
+### Installation / Configuration
 
  * After installing the `alfresco-s3.amp` package you will need to add some properties to your `alfresco-global.properties` file:
  
@@ -28,6 +30,9 @@ aws.regionName=us-east-1
 # The S3 bucket name to use as the content store
 aws.s3.bucketName=
 
+#The url endpoint for the S3 server
+aws.s3.url=http://minio:9000
+
 # The location on local storage to be used as the cache
 dir.cachedcontent=/temp/cachedcontent
 
@@ -38,4 +43,4 @@ dir.contentstore=/alfresco/contentstore
 dir.contentstore.deleted=/alfresco/contentstore.deleted
 ```
  
- 
+ * Alternatively, edit the `alfresco-global.properties` file located in src/main/amp/config/alfresco/module/alfresco-s3/

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,12 @@
         <dependency>
             <groupId>${alfresco.groupId}</groupId>
             <artifactId>alfresco-repository</artifactId>
+            <exclusions>
+                <exclusion> <!-- exclude facebook social since its dropped from the repo -->
+                    <groupId>org.springframework.social</groupId>
+                    <artifactId>spring-social-facebook</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- aws sdk -->

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.ryanberg</groupId>
     <artifactId>alfresco-s3</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <name>alfresco-s3 Repository AMP project</name>
     <packaging>amp</packaging>
     <description>Manages the lifecycle of the alfresco-s3 Repository AMP (Alfresco Module Package)</description>
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.alfresco.maven</groupId>
         <artifactId>alfresco-sdk-parent</artifactId>
-        <version>2.1.0</version>
+        <version>2.1.1</version>
     </parent>
 
     <!-- 
@@ -23,8 +23,9 @@
     <properties>
         <!-- The following are default values for data location and Alfresco Community version.
              Uncomment if you need to change (Note. current default version for Enterprise edition is 5.0.1)
-          <alfresco.version>5.0.d</alfresco.version>
           <alfresco.data.location>alf_data_dev</alfresco.data.location> -->
+
+        <alfresco.version>6.2.0-ga</alfresco.version>
 
         <!-- This control the root logging level for all apps uncomment and change, defaults to WARN
             <app.log.root.level>WARN</app.log.root.level>
@@ -48,7 +49,7 @@
             -->
             <dependency>
                 <groupId>${alfresco.groupId}</groupId>
-                <artifactId>alfresco-platform-distribution</artifactId>
+                <artifactId>alfresco-content-services-community-distribution</artifactId>
                 <version>${alfresco.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
@@ -75,7 +76,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.9.39</version>
+            <version>1.11.106</version>
         </dependency>
 
     </dependencies>

--- a/src/main/amp/config/alfresco/module/alfresco-s3/alfresco-global.properties
+++ b/src/main/amp/config/alfresco/module/alfresco-s3/alfresco-global.properties
@@ -11,8 +11,11 @@ aws.regionName=us-east-1
 # The S3 bucket name to use as the content store
 aws.s3.bucketName=
 
+#The S3 endpoint url
+aws.s3.url=
+
 # The location on local storage to be used as the cache
-dir.cachedcontent=/temp/cachedcontent
+dir.cachedcontent=/usr/local/tomcat/alf_data
 
 # The relative path (S3 KEY) within the bucket to use as the content store (useful if the bucket is not dedicated to alfresco content)
 dir.contentstore=/alfresco/contentstore

--- a/src/main/amp/config/alfresco/module/alfresco-s3/module-context.xml
+++ b/src/main/amp/config/alfresco/module/alfresco-s3/module-context.xml
@@ -34,6 +34,7 @@
 		<property name="bucketName" value="${aws.s3.bucketName}"/>
 		<property name="regionName" value="${aws.regionName}"/>
 		<property name="rootDirectory" value="${dir.contentstore.deleted}"/>
+                <property name="url" value="${aws.s3.url}"/>
 	</bean>
 
 	<bean id="contentCache" class="org.alfresco.repo.content.caching.ContentCacheImpl">
@@ -55,15 +56,13 @@
 		<property name="cleaner" ref="cachedContentCleaner"/>
 	</bean>
 
-	<bean id="cachingContentStoreCleanerJobDetail" class="org.springframework.scheduling.quartz.JobDetailBean">
+	<bean id="cachingContentStoreCleanerJobDetail" class="org.springframework.scheduling.quartz.JobDetailFactoryBean">
 		<property name="jobClass">
 			<value>org.alfresco.repo.content.caching.cleanup.CachedContentCleanupJob</value>
 		</property>
 		<property name="jobDataAsMap">
 			<map>
-				<entry key="cachedContentCleaner">
-					<ref bean="cachedContentCleaner" />
-				</entry>
+				<entry key="cachedContentCleaner" value-ref="cachedContentCleaner"/>
 			</map>
 		</property>
 	</bean>
@@ -77,17 +76,21 @@
 		<property name="usageTracker" ref="standardQuotaManager"/>
 	</bean>
 
-	<bean id="cachingContentStoreCleanerTrigger" class="org.alfresco.util.CronTriggerBean">
-		<property name="jobDetail">
-			<ref bean="cachingContentStoreCleanerJobDetail" />
-		</property>
-		<property name="scheduler">
-			<ref bean="schedulerFactory" />
-		</property>
-		<property name="cronExpression">
-			<value>${system.content.caching.contentCleanup.cronExpression}</value>
-		</property>
-	</bean>
+        <bean id="cachingContentStoreCleanerSchedulerAccessor" class="org.alfresco.schedule.AlfrescoSchedulerAccessorBean">
+        	<property name="scheduler" ref="schedulerFactory"/>
+        	<property name="triggers">
+            		<list>
+				<bean id="cachingContentStoreCleanerTrigger" class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
+                			<property name="jobDetail">
+                        		<ref bean="cachingContentStoreCleanerJobDetail" />
+                			</property>
+                			<property name="cronExpression">
+                        		<value>${system.content.caching.contentCleanup.cronExpression}</value>
+                			</property>
+        			</bean>
+            		</list>
+        	</property>
+    	</bean>
 
 	<bean id="com.ryanberg.alfresco.s3.S3ContentStore" class="com.ryanberg.alfresco.s3.S3ContentStore" init-method="init">
 		<property name="accessKey" value="${aws.accessKey}"/>
@@ -95,6 +98,7 @@
 		<property name="bucketName" value="${aws.s3.bucketName}"/>
 		<property name="regionName" value="${aws.regionName}"/>
 		<property name="rootDirectory" value="${dir.contentstore}"/>
+                <property name="url" value="${aws.s3.url}"/>
 	</bean>
 
 </beans>


### PR DESCRIPTION
This updates the module to work for alfresco 6.2.0, and adds a new parameter to the `alfresco-global.properties` file, `aws.s3.url` which specifies the S3 endpoint URL.